### PR TITLE
TEC-1299: fix(gsuite): unblock scuba.py import on Python 3.12

### DIFF
--- a/gsuite/gsuite_scan.py
+++ b/gsuite/gsuite_scan.py
@@ -329,7 +329,27 @@ Please follow these steps before continuing:
                 cwd=self.scubagoggles_dir,
                 check=True,
             )
-            print("ScubaGoggles cloned and checked out successfully")
+
+            # Patch out the sys.path.insert that shadows stdlib `types` on
+            # Python 3.12+. scuba.py at f104430 does
+            # `sys.path.insert(1, './scubagoggles')`, which puts the internal
+            # package dir on sys.path; stdlib enum.py's `from types import ...`
+            # then resolves to scubagoggles/types.py and circular-imports.
+            scuba_py = os.path.join(self.scubagoggles_dir, 'scuba.py')
+            with open(scuba_py, 'r') as f:
+                contents = f.read()
+            patched = contents.replace(
+                "import sys\nsys.path.insert(1, './scubagoggles')\n\n", ""
+            )
+            if patched == contents:
+                raise RuntimeError(
+                    "Failed to patch scuba.py: expected sys.path.insert "
+                    "line not found. The pinned commit may have changed."
+                )
+            with open(scuba_py, 'w') as f:
+                f.write(patched)
+
+            print("ScubaGoggles cloned, checked out, and patched successfully")
         except subprocess.CalledProcessError as e:
             print(f"Error setting up ScubaGoggles: {str(e)}")
             raise


### PR DESCRIPTION
**Jira:** [TEC-1299](https://corsis.atlassian.net/browse/TEC-1299)

## Summary

Unblocks `gsuite_scan.py` for users on Python 3.12+. After `git checkout` of the pinned ScubaGoggles commit, we strip one offending line from the cloned `scuba.py` and continue as before. Pin stays at `f104430`.

## What was reported

A target company running this script on their own machine (pyenv Python 3.12.2) as part of an ongoing TDD engagement hit this when running the scan:

```
File ".../scubagoggles/main.py", line 8, in <module>
    import argparse
...
File ".../enum.py", line 3, in <module>
    from types import MappingProxyType, DynamicClassAttribute
File ".../scubagoggles/types.py", line 6, in <module>
    from enum import Enum
ImportError: cannot import name 'Enum' from partially initialized module
'enum' (most likely due to a circular import)
```

Their working theory was "the script is pinned to an old ScubaGoggles commit; bump the pin." That's directionally right but not quite the root cause.

## Why is this only failing now?

This script has been run successfully multiple times since Collins's freeze (Dec 2025) without anyone hitting this error, so the failure surfacing now is naturally surprising. The reason is that the bug is **latent and environment-specific** — it's been sitting in the cloned code since the freeze, but it only fires on a specific Python interpreter build combination:

- **Python 3.10 / 3.11** — never fires. stdlib `enum.py` doesn't import `types` at module init in those versions, so the collision chain never gets a chance to start.
- **Python 3.12+, with `enum` preloaded into `sys.modules` at interpreter startup** — never fires. The cached `enum` module is reused, no re-execution, no `from types import ...` call during user-code import. Homebrew's Python 3.12 builds (we tested 3.12.13 locally) fall into this bucket.
- **Python 3.12+, with `enum` *not* preloaded at startup** — fires deterministically every run. Pyenv 3.12.2 (the reporting target company's environment) is in this bucket.

So every prior successful scan was run on an interpreter where the trigger condition didn't apply. Nothing changed about the script or our codebase between those runs and this one — this particular user happens to be on the one Python build combination where the latent bug fires. Once this fix lands, the trigger condition is removed from the script entirely, so no future user can hit it regardless of which Python 3.12 build they're using.

## What we found

The pinned `scuba.py` at `f104430` (March 2024) starts with:

```python
import sys
sys.path.insert(1, './scubagoggles')

from scubagoggles.main import dive
```

That `sys.path.insert` puts the *internal* `scubagoggles/` package directory onto `sys.path`. The chain then plays out like this when `scuba.py` is run on Python 3.12+:

1. `from scubagoggles.main import dive` → `scubagoggles/main.py`
2. `main.py` does `import argparse`
3. stdlib `argparse` does `import re`
4. stdlib `re` does `import enum`
5. stdlib `enum.py` (line 3) does `from types import MappingProxyType, DynamicClassAttribute`
6. Python searches `sys.path` for `types` — and finds `scubagoggles/types.py` (a module defining the unrelated `ApiReference` enum) before the stdlib `types` module
7. That file does `from enum import Enum` — but `enum` is still mid-initialization → circular import → crash

So the bug is the `sys.path.insert` plus a coincidentally-named module, not the age of the pin per se. On Python 3.10/3.11, stdlib `enum.py` doesn't import `types` at module init the same way, so the bug never surfaces. Different Python 3.12 builds also vary: pyenv 3.12.2 re-executes `enum` during this chain and hits the bug; homebrew 3.12.13 preloads `enum` into `sys.modules` at interpreter startup and sidesteps it. The user-reported environment is the bad case.

## Context on the pin

For history, this is how `vp-scripts-public/gsuite/gsuite_scan.py` got to its current pinning state:

- **2024-03-29** — ScubaGoggles commit `f104430` lands upstream. Still has the `sys.path.insert` hack and `scubagoggles/types.py`.
- **2024-09-09** — upstream deletes `scubagoggles/types.py` (commit `127bf6b`).
- **2024-12-19** — upstream converts ScubaGoggles to a pip-installable package (commit `2219d49`, "Policy API Integration #499"). The `sys.path.insert` hack is removed; `pyproject.toml` adds a console entry point: `scubagoggles = "scubagoggles.main:dive"`. Bug class is eliminated by construction.
- **2025-04-16** — upstream removes `download_opa.py` (replaced by `scubagoggles getopa` subcommand and the `scubagoggles setup` flow).
- **2025-07-11** — upstream releases **v0.5.0**, the first tagged pip-installable release.
- **2025-12-19** — Collins Abitekaniza froze our wrapper to `f104430` in commit [`753f206`](../commit/753f206f6248ab15ce82e91424126471488df057), exactly one year *after* upstream went pip-installable and five months *after* v0.5.0 shipped. No rationale recorded in the commit message or in the code. Collins is no longer on the team, so we can't ask him. Most likely interpretation, based on the shape of the commit: he was pinning to a local working clone, not deliberately walking past v0.5.0. Before his change, the script did `git clone` of upstream HEAD with no pin — meaning every run pulled whatever was current, which makes for non-reproducible behavior. He probably ran into a flaky/changed upstream and decided to "freeze it to what works on my machine." The SHA he chose (`f104430`, a March 2024 mid-development hash rather than any tagged release) is what `git rev-parse HEAD` would have returned in a local clone that hadn't been refreshed in about a year and a half. Tagged releases like `v0.4.1` or `v0.5.0` would have been the obvious choice if he were deliberately picking a "known-good" version. So this is less "Collins rejected v0.5.0" and more "Collins didn't know v0.5.0 existed because his clone was stale."

## What this PR does (the quick patch)

In `clone_scubagoggles()`, after `git checkout f104430`, we read the cloned `scuba.py` and strip the offending block:

```python
patched = contents.replace(
    "import sys\nsys.path.insert(1, './scubagoggles')\n\n", ""
)
if patched == contents:
    raise RuntimeError(
        "Failed to patch scuba.py: expected sys.path.insert "
        "line not found. The pinned commit may have changed."
    )
```

The `raise` is intentional: if anyone re-pins or upstream changes the file shape, we want a loud failure rather than a silent no-op that lets the bug return.

## How the patch unblocks execution

Before the patch, `sys.path` inside the running `scuba.py` looks like:

```
[
    '<ScubaGoggles>',           # sys.path[0] — Python sets this because scuba.py lives here
    './scubagoggles',           # inserted by scuba.py line 11 (the bug)
    ...stdlib paths...
]
```

When stdlib `enum.py` executes `from types import MappingProxyType, DynamicClassAttribute` during its own initialization, Python walks `sys.path` in order looking for a `types` module:

1. `<ScubaGoggles>/types.py` — doesn't exist, skip.
2. `<ScubaGoggles>/scubagoggles/types.py` — **exists**, import it.

That second entry is the package's *internal* `types` module (it defines an unrelated `ApiReference` enum). Its first real line is `from enum import Enum` — but `enum` is in the middle of being initialized, so the partially-loaded `enum` module doesn't yet have `Enum` defined. ImportError, circular import, scan fails.

After the patch, `sys.path` looks like:

```
[
    '<ScubaGoggles>',           # sys.path[0]
    ...stdlib paths...
]
```

Python's `types` lookup now skips straight past `<ScubaGoggles>/` (no `types.py` at the top level) to the stdlib `types` module — a small, self-contained utility module that doesn't try to import anything still loading. `enum` finishes initializing, `re` finishes, `argparse` finishes, `scubagoggles.main` finishes importing, and the scan proceeds normally.

The `scubagoggles` package's own internal references to its `types` module — e.g. `from scubagoggles.types import ApiReference` in `scubagoggles/provider.py` and `scubagoggles/reporter/reporter.py` — still work because those are *qualified* imports. Python resolves them through the `scubagoggles` package (which it finds via the first sys.path entry `<ScubaGoggles>/`), not by bare-name lookup. Grep confirmed at the pinned commit: zero bare `from types import` or `import types` inside the package, so nothing inside scubagoggles ever needed the deleted sys.path entry.

No CLI, baseline, or output-format changes. The scan should produce identical results to what `f104430` was already producing.

## What the proper fix is (deferred)

The bug class is structurally absent in the current upstream. Long-term we should modernize this wrapper to install ScubaGoggles via pip rather than clone-and-checkout:

- `pip install scubagoggles==0.6.0` into a per-run venv
- Replace `python3 scuba.py gws ...` with the `scubagoggles gws ...` console entry point
- Replace the manual `python3 download_opa.py` step with `scubagoggles getopa` (or run `scubagoggles setup` once during venv bootstrap)

Every CLI flag this wrapper passes (`--customerid`, `--subjectemail`, `-c`, `-o`, `--debug`, `--opapath`) still exists at v0.6.0. The output file layout (`ProviderSettingsExport.json`, `TestResults.json`, `BaselineReports.html` inside `GWSBaselineConformance/`) is unchanged.

That work is **not in this PR** because it (a) reverses a deliberate freeze whose rationale we don't have, and (b) needs validation against a real Workspace tenant to confirm the ~2 years of baseline-content updates don't break anything downstream of us. We don't currently have a Crosslake test Workspace tenant — getting one would unblock this.

## Validation

5/5 automated checks pass on Python 3.12.13 (scratch script, not committed to the repo). Each check exits non-zero on failure:

1. **Necessary conditions on unpatched `f104430`** — confirms `scubagoggles/types.py` exists and imports `Enum`, and `scuba.py` contains the `sys.path.insert` line.
2. **Production patch** — applies the exact string replacement from `clone_scubagoggles()` and confirms `scuba.py` no longer contains the offending block.
3. **`scuba.py --help` succeeds** — in a venv with `gsuite/requirements.txt` installed, after the patch.
4. **CLI args intact** — `scuba.py gws --help` lists every flag the wrapper passes (`--customerid`, `--subjectemail`, `--credentials`, `--outputpath`, `--debug`, `--opapath`).
5. **Wrapper smoke test** — invokes `ScubaGogglesAutomation.clone_scubagoggles()` end-to-end and confirms the resulting checkout has the patch applied and runs `scuba.py --help` successfully.

We did **not** validate end-to-end scan output against a real Workspace tenant — we don't have one. That risk is acceptable for this PR because nothing about the patch changes scan behavior; it only fixes the import chain.

## Test plan for reviewers

- [ ] Pull this branch and run `gsuite/gsuite_scan.py` against a real Workspace tenant on Python 3.12+ — confirm the scan completes without the `circular import` traceback.
- [ ] Confirm the patch-not-applied error path triggers if you temporarily corrupt the patch needle in `clone_scubagoggles()` (sanity-check the `RuntimeError` works).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the handling of external dependencies during initialization to ensure correct import resolution and prevent conflicts.
  * Fixed the external tool checkout process to apply necessary runtime patches reliably and provide clearer cloning/checkout status messages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/corsis-tech/vp-scripts-public/pull/5)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



[TEC-1299]: https://corsis.atlassian.net/browse/TEC-1299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ